### PR TITLE
Updating the clj-time library to use the newly renamed in-seconds

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,5 @@
                  [org.clojure/tools.logging "0.2.6"]
                  [ring/ring-core "1.2.0"]
                  [com.cemerick/friend "0.1.5"]
-                 [clj-time "0.5.1"]
+                 [clj-time "0.6.0"]
                  [cheshire "5.2.0"]])

--- a/src/tombooth/friend_token/token_store.clj
+++ b/src/tombooth/friend_token/token_store.clj
@@ -11,7 +11,7 @@
 
 (defn- within-ttl?
   [token-data ttl]
-  (let [seconds-passed (time/in-secs (time/interval (:created token-data) (time/now)))]
+  (let [seconds-passed (time/in-seconds (time/interval (:created token-data) (time/now)))]
     (< seconds-passed ttl)))
 
 (defrecord MemTokenStore


### PR DESCRIPTION
Thank you for your library!
My project is using this and the more updated clj-time. Because of this, I am getting deprecation warnings. Would you want to merge in an update to bring this more up to date?
Thanks!
Steve
